### PR TITLE
Fix some small typos

### DIFF
--- a/cubeapp/logout_success.py
+++ b/cubeapp/logout_success.py
@@ -2,7 +2,7 @@ from django.contrib.auth.signals import user_logged_out, user_login_failed
 from django.contrib import messages
 
 
-def show_message_logout_succes(sender, user, request, **kwargs):
+def show_message_logout_success(sender, user, request, **kwargs):
     messages.success(request, 'You have been successfully logged out.')
 
 
@@ -10,5 +10,5 @@ def show_message_login_fail(sender, credentials, request, **kwargs):
     messages.success(request, 'Login failed. Incorrect username or password.')
 
 
-user_logged_out.connect(show_message_logout_succes)
+user_logged_out.connect(show_message_logout_success)
 user_login_failed.connect(show_message_login_fail)

--- a/cubeapp/templates/cubeapp/user_detail.html
+++ b/cubeapp/templates/cubeapp/user_detail.html
@@ -15,7 +15,7 @@
 		<td>{{object.email}}</td>
 	</tr>
 </table>
-<h2>Alphabet prefrences</h2>
+<h2>Alphabet preferences</h2>
 {% if illegalletters.count != 0 %}
 	
 <table class="table table-bordered">

--- a/cubeapp/views.py
+++ b/cubeapp/views.py
@@ -33,8 +33,8 @@ class LoginSuccessView(SuccessMessageMixin, LoginView):
     success_message = 'Succesfully logged in!'
     succes_url = '/admin'
 
-    def get_succes_message(self, cleaned_data):
-        return 'login succes'
+    def get_success_message(self, cleaned_data):
+        return 'login success'
 
 
 class AbbreviationDetail(DetailView):


### PR DESCRIPTION
These are all cosmetic *apart* from the fix for the method name `get_success_message`, which was stopping the message from appearing. The default message is empty, and the mixin doesn't post the empty message ([source](https://github.com/django/django/blob/b9cf764be62e77b4777b3a75ec256f6209a57671/django/contrib/messages/views.py#L13)), so nothing was happening. Python doesn't really have a mechanism for automatically catching such typos - you can add any method you want on any subclass, no problem. Really the way to catch this kind of bug is with some testing, automated or manual :) :)