### PR TITLE
Remove extra database query in user preferences template

### DIFF
--- a/cubeapp/templates/cubeapp/user_detail.html
+++ b/cubeapp/templates/cubeapp/user_detail.html
@@ -16,8 +16,8 @@
 	</tr>
 </table>
 <h2>Alphabet prefrences</h2>
-{% if illegalletters.count != 0 %}
-	
+{% if illegalletters %}
+
 <table class="table table-bordered">
 	{% for illegalletter in illegalletters %}
 	<tr class="table-{% if illegalletter.replace != '' %}warning{% else %}danger{% endif %}">


### PR DESCRIPTION
With the access of `.count`, which Django templates then sees to be a function on the QuerySet and calls, a database query is performed to check the number of 'illegal letters'. Then later in the template, the original QuerySet is iterated, which means that its main query is executing, fetching that list of illegal letters. Thus, two database queries are executed, even though *one* needs to be.

The simple fix is to move to test the queryset to begin with (it looks like a list, and in Python, the empty list is 'falsey' and lists containing any elements are 'truthy'). This will run the main query on the first access, fetching (and caching) the list of elements, and then in the following iteration the same list of items (from the local cache) is used, avoiding a second query.

(And in fact, the first version is worse than just losing some time doing an extra query - there's a concurrency bug, as there's a chance for a parallel web request/process to modify the list of items in the database between the two queries, depending on the SQL isolation mode... lots for you to research if you have the time!)